### PR TITLE
fix: GitHub Packages publish auth and release 2.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
+          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.1] - 2026-04-09
+
+### Fixed
+
+- GitHub Actions publish workflow: set `registry-url` to `https://npm.pkg.github.com` in the GitHub Packages job so `npm publish` receives credentials (`ENEEDAUTH` without it).
+
 ## [2.0.0] - 2026-02-10
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "is-midi",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "is-midi",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "ava": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-midi",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Check if a Buffer/Uint8Array is a MIDI file (supports standard MIDI and RIFF MIDI/.rmi)",
   "license": "MIT",
   "repository": {
@@ -63,6 +63,9 @@
     }
   },
   "c8": {
-    "reporter": ["text", "lcov"]
+    "reporter": [
+      "text",
+      "lcov"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- **GitHub Actions:** set `registry-url: https://npm.pkg.github.com` on `actions/setup-node` in the GitHub Packages publish job so `npm publish` authenticates (`NODE_AUTH_TOKEN` / `ENEEDAUTH` fix).
- **Release:** bump to `2.1.1` and document the change in `CHANGELOG.md`.

## Context

Publishing to `npm.pkg.github.com` failed after merge with `ENEEDAUTH` because npm had no registry auth line in `.npmrc` without `setup-node`'s `registry-url`.

Made with [Cursor](https://cursor.com)