### PR TITLE
fix: publish workflow (GitHub Packages auth, npm OIDC, Node 24-only verify)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,24 +13,20 @@ concurrency:
 
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
+    name: Test (Node.js 24)
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      id-token: write # Codecov tokenless / OIDC upload on Node 24
-
-    strategy:
-      matrix:
-        node-version: [18, 20, 22, 24]
+      id-token: write # Codecov tokenless / OIDC upload
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24
           cache: npm
 
       - run: npm ci
@@ -40,7 +36,6 @@ jobs:
       - run: npm run test:coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == 24
         uses: codecov/codecov-action@v5
 
   resolve-version:
@@ -129,6 +124,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Ensure npm supports OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm (trusted publishing / OIDC)
         run: npm publish --access public
 
@@ -142,6 +140,9 @@ jobs:
       contents: read
       packages: write
 
+    env:
+      NODE_AUTH_TOKEN: ${{ github.token }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -149,18 +150,18 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
 
       - name: Publish scoped package to GitHub Packages
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
           GITHUB_PKG_NAME: ${{ needs.resolve-version.outputs.github_pkg_name }}
         run: |
           set -euo pipefail
           cp package.json package.json.ci-backup
           npm pkg set "name=${GITHUB_PKG_NAME}"
           npm pkg set publishConfig.registry=https://npm.pkg.github.com
-          npm publish --registry https://npm.pkg.github.com
+          npmrc="${RUNNER_TEMP}/npmrc-github-publish"
+          printf '%s\n' "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > "${npmrc}"
+          npm publish --registry https://npm.pkg.github.com --userconfig "${npmrc}"
           mv package.json.ci-backup package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.2] - 2026-04-10
+
+### Fixed
+
+- GitHub Actions: GitHub Packages publish job now uses a dedicated npm `--userconfig` for auth and leaves `setup-node` on the default registry for `npm ci`, avoiding `ENEEDAUTH` to `npm.pkg.github.com`.
+- GitHub Actions: npm registry publish continues to use OIDC trusted publishing with `npm@latest` so the CLI meets the npm 11.5.1+ OIDC requirement.
+
+### Changed
+
+- `repository.url` in `package.json` uses `https://github.com/chrisvogt/is-midi.git` for npm trusted publishing validation.
+
 ## [2.1.1] - 2026-04-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "is-midi",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "is-midi",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "devDependencies": {
         "ava": "^6.1.1",
@@ -751,6 +751,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -1261,6 +1262,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1721,6 +1723,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2787,6 +2790,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2863,6 +2867,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6245,6 +6250,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7506,6 +7512,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "is-midi",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Check if a Buffer/Uint8Array is a MIDI file (supports standard MIDI and RIFF MIDI/.rmi)",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chrisvogt/is-midi.git"
+    "url": "https://github.com/chrisvogt/is-midi.git"
   },
   "author": {
     "name": "Chris Vogt",


### PR DESCRIPTION
## Summary

- **GitHub Packages:** publish with a dedicated npm `--userconfig` and job-level `NODE_AUTH_TOKEN`; drop `registry-url` on `setup-node` in that job so `npm ci` stays on npmjs.
- **npm:** keep OIDC trusted publishing with `npm install -g npm@latest` before publish; `repository.url` uses `https://github.com/chrisvogt/is-midi.git`.
- **Publish workflow `test` job:** run only on **Node.js 24** (matrix remains on `ci.yml` for PRs).
- **Release:** bump to **2.1.2** and document in `CHANGELOG.md`.

Made with [Cursor](https://cursor.com)